### PR TITLE
Refine deployment, release, and Field Services docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,25 +117,23 @@ Once you have the application set up and dependencies installed, you can run the
 
 ## Building the Application
 
-To build the application for release using Expo, you can use **Expo's build service**.
+Builds are created with EAS Build profiles. Do not edit `src/constants.js` to switch environments.
 
-### For iOS:
-
-To build the iOS app, run the following command:
+Testing / QA build:
 
 ```bash
-npx expo build:ios
+eas build --profile preview --platform android
+eas build --profile preview --platform ios
 ```
 
-This will guide you through the process of building the iOS app and generate a build that can be deployed to TestFlight.
-
-### For Android:
+Production build:
 
 ```bash
-npx expo build:android
+eas build --profile production --platform android
+eas build --profile production --platform ios
 ```
 
-This will generate an APK or AAB file that can be distributed to users or uploaded to the Google Play Store.
+For environment mapping, versioning, and store upload notes, see [Build and Release Notes](./docs/build-and-release.md).
 
 ## Folder Structure
 

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -60,6 +60,49 @@ $env:EAS_NO_VCS="1"; eas build --profile preview --platform android
 
 This should be treated as a local workaround. The preferred long-term setup is to have Git installed and available in PATH.
 
+## Testing Distribution
+
+### Android
+
+Create a testing build:
+
+```bash
+eas build --profile preview --platform android
+```
+
+Upload the generated `.aab` to Google Play Console:
+
+1. Open the app in Google Play Console.
+2. Go to Testing.
+3. Choose Internal testing or Closed testing.
+4. Create a new release.
+5. Upload the `.aab`.
+6. Add release notes.
+7. Review and roll out to testers.
+
+### iOS
+
+Create a testing build:
+
+```bash
+eas build --profile preview --platform ios
+```
+
+Submit to App Store Connect:
+
+```bash
+eas submit --platform ios
+```
+
+Then in App Store Connect:
+
+1. Open the app.
+2. Go to TestFlight.
+3. Wait for Apple processing.
+4. Add the build to the tester group.
+5. Add test notes if required.
+6. Start testing.
+
 ## Versioning
 
 There are two version concepts:

--- a/docs/deployment-guidelines.md
+++ b/docs/deployment-guidelines.md
@@ -1,6 +1,8 @@
-# Deployment Guidelines – ibe-mobile
+﻿# Deployment Guidelines - ibe-mobile
 
 This document describes the Git-based deployment workflow for the **ibe-mobile** React Native project. It ensures consistency, stability, and clear handoffs between developers, QA, and production.
+
+For build commands, EAS profiles, environment selection, and versioning, see [Build and Release Notes](./build-and-release.md).
 
 ---
 
@@ -8,43 +10,55 @@ This document describes the Git-based deployment workflow for the **ibe-mobile**
 
 We follow a multi-environment flow using the following permanent branches:
 
-| Branch     | Purpose                                   |
-|------------|-------------------------------------------|
-| `develop`  | Developer integration, internal testing   |
-| `staging`  | QA/UAT testing (prior to production)      |
-| `main`     | Stable, production-ready code             |
+| Branch | Purpose |
+| --- | --- |
+| `develop` | Developer integration, internal testing |
+| `staging` | QA/UAT testing prior to production |
+| `main` | Stable, production-ready code |
 
 ---
 
-## Deployment Process (Git Flow)
+## Deployment Process
 
 ### 1. Feature Development
+
 - Developers branch from `develop`:
+
   ```bash
   git checkout develop
   git pull origin develop
   git checkout -b feature/your-feature-name
   ```
-- Implement changes and open a **Pull Request (PR)** into `develop`.
-- All PRs must pass **CI checks** (lint, build, tests) and be reviewed.
+
+- Implement changes and open a pull request into `develop`.
+- Pull requests should pass lint, build, and test checks where available.
+- Changes should be reviewed before merge.
 
 ---
 
-### 2. Internal QA (Develop Environment)
-- Merge **feature branches** into `develop` via PR.
-- Test **individual features** and **integration flows** in the `develop` environment.
+### 2. Internal QA
+
+- Merge feature branches into `develop` via pull request.
+- Test individual features and integration flows in the development environment.
+- Use the EAS `development` profile when a development build is needed.
 
 ---
 
-### 3. QA/UAT Testing (Staging)
-- Once `develop` is stable (end of sprint/release candidate), merge `develop` → `staging`.
-- The **QA team** conducts user testing on `staging` builds.
+### 3. QA/UAT Testing
+
+- Once `develop` is stable, merge `develop` -> `staging`.
+- QA conducts user testing on staging builds.
+- Use the EAS `preview` profile for QA/testing builds.
+- The `preview` profile points to the testing backend environment.
 
 ---
 
-### 4. Production (Main)
-- After QA sign-off, merge `staging` → `main`.
+### 4. Production
+
+- After QA sign-off, merge `staging` -> `main`.
+- Use the EAS `production` profile for production builds.
 - Tag the release for traceability:
+
   ```bash
   git checkout main
   git merge staging
@@ -55,13 +69,45 @@ We follow a multi-environment flow using the following permanent branches:
 ---
 
 ### 5. Hotfixes
-- For urgent production issues:
-  - Branch from `main` → fix → merge back into **both** `main` and `develop`.
-  - Tag and release as a patch version (`v1.2.1`).
+
+For urgent production issues:
+
+- Branch from `main`.
+- Fix and validate the issue.
+- Merge back into both `main` and `develop`.
+- Tag and release as a patch version, for example `v1.2.1`.
 
 ---
 
-## Remote Tracking (One-Time Setup)
+## Build Profile Mapping
+
+Branch strategy and EAS build profiles should normally align as follows:
+
+| Branch | Purpose | EAS profile | Backend environment |
+| --- | --- | --- | --- |
+| `develop` | Developer integration | `development` | `development` |
+| `staging` | QA/UAT testing | `preview` | `testing` |
+| `main` | Production release | `production` | `production` |
+
+Do not edit `src/constants.js` to switch environments. Use EAS profiles and `APP_ENV` as described in [Build and Release Notes](./build-and-release.md).
+
+---
+
+## Release Checklist
+
+Before a testing or production build:
+
+- Confirm the branch is correct.
+- Confirm the build profile points to the intended backend environment.
+- Run lint/tests where applicable.
+- Confirm `expo.version` changes only when the user-facing release version changes.
+- Let EAS auto-increment native build numbers.
+- Record release notes for testers or app store reviewers.
+
+---
+
+## Remote Tracking
+
 Make sure local branches track the correct remotes:
 
 ```bash
@@ -75,32 +121,30 @@ git checkout main
 git branch --set-upstream-to=origin/main
 ```
 
-This avoids confusion and ensures clean push/pull operations.
+This avoids confusion and helps keep push/pull operations predictable.
 
 ---
 
 ## Recommended Merge Schedule
 
-| Environment | Suggested Frequency                |
-|-------------|-------------------------------------|
-| `develop`   | Daily (as features are completed)   |
-| `staging`   | Weekly (end of sprint or QA cycle)  |
-| `main`      | Monthly or post-release validation  |
+| Environment | Suggested Frequency |
+| --- | --- |
+| `develop` | Daily, as features are completed |
+| `staging` | Weekly, end of sprint, or QA cycle |
+| `main` | Post-release validation or approved release window |
 
-> Adjust frequency based on release cycles, sprint reviews, or customer requirements.
+Adjust frequency based on release cycles, sprint reviews, and customer requirements.
 
 ---
 
 ## Best Practices
-- Always branch from `develop` for features
-- Keep `main` clean and always deployable
-- Enforce PR reviews + CI checks before merging
-- Tag every production release (`vX.Y.Z`)
-- Avoid force pushes on shared branches
-- Automate builds:
-  - **Develop → internal build**
-  - **Staging → QA build**
-  - **Main → production release**
+
+- Always branch from `develop` for features.
+- Keep `main` clean and always deployable.
+- Enforce pull request reviews before merging.
+- Tag every production release as `vX.Y.Z`.
+- Avoid force pushes on shared branches.
+- Keep build/release commands in [Build and Release Notes](./build-and-release.md) instead of duplicating them here.
 
 ---
 

--- a/docs/field-services-module.md
+++ b/docs/field-services-module.md
@@ -259,9 +259,38 @@ Recommended test flow:
 13. Complete the job.
 14. Reopen the job and confirm execution state was saved to backend.
 
-## Known Technical Debt
+## Known Limitations and Technical Debt
 
-- Client-specific review item overrides live in mobile code until backend configuration supports all required source paths consistently.
-- PDF preview support depends on platform capabilities. A native PDF viewer dependency should be considered for production-grade in-app PDF viewing.
-- Notifications and offline sync behavior should be verified separately if required for production rollout.
+### Configuration
+
+- Some customer review items are still resolved through client-specific mobile overrides in `src/config/fieldServiceReviewOverrides.js`.
+- The preferred long-term design is to keep review item definitions fully backend-configurable through `FieldServiceReviewTemplate`.
+- Mobile overrides should be treated as temporary compatibility logic for customer/project data that is not yet normalized in backend configuration.
+
+### Documents and Preview
+
+- PDF and document handling depends on platform capabilities.
+- Unsupported document types are offered for download/share instead of in-app preview.
+- A native PDF viewer dependency should be considered if production requires reliable in-app PDF viewing across Android and iOS.
+
+### Notifications and Offline Use
+
+- Assignment notifications still need separate production validation if they are required for rollout.
+- Offline execution and sync conflict handling should be reviewed before supporting disconnected field work as a formal requirement.
+
+### Access and Authentication
+
 - Role values must be returned reliably in authentication data as `accessRoles` / `User-accessRoles`.
+- The app does not use `User-access` for Field Services authorization because that field is boolean.
+
+### Backend Consistency
+
+- Field Services objects must exist in backend metadata and collections before mobile execution data can be saved reliably.
+- Checklist, review template, policy, and execution objects should be included in deployment/setup scripts for each environment.
+- Existing tasks may not have matching Field Services execution records; the mobile app creates execution state as users start interacting with the assignment.
+
+### Testing Gaps
+
+- End-to-end completion should be tested on both Android and iOS real devices.
+- Store/TestFlight builds should verify camera, location, document preview/download, call, email, and map actions.
+- Large assignment lists should be tested with realistic production-like task volumes and policy cutoff dates.


### PR DESCRIPTION
- Make deployment guidelines module-neutral
- Link deployment flow to EAS build and release notes
- Replace outdated Expo build commands with EAS build profiles
- Document testing distribution steps
- Clarify Field Services limitations and technical debt